### PR TITLE
Support Nested JSON Objects

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,17 +13,17 @@ Available via: [![Go Walker](http://gowalker.org/api/v1/badge)](https://gowalker
 All the config types including the root implement the Configurable interface.
 
 ```go
-/ The main Configurable interface
+// The main Configurable interface
 // Also the hierarcial configuration (Config) implements it.
 type Configurable interface {
   // Get a configuration variable from config
-  Get(string) interface{}
+  Get(string) string
   // Set a variable, nil to reset key
-  Set(string, interface{})
+  Set(string, string)
   // Reset the config data to passed data, if nothing is given set it to zero value
-  Reset(...map[string]interface{})
+  Reset(...map[string]string)
   // Return a map of all variables
-  All() map[string]interface{}
+  All() map[string]string
 }
 
 type WritebleConfig interface {

--- a/config_valid.json
+++ b/config_valid.json
@@ -3,8 +3,15 @@
   "test_b":"abc",
   "test_number":1,
   "test_array":[1,2,3],
+  "test_bool": true,
+  "test_float": 12.34,
   "test_object": {
-    "test_a":1,
-    "test_b":"b"
+    "nested_int": 987,
+    "nested_string": "abcd"
+  },
+  "double_nested": {
+    "nested_object": {
+      "test_inner": "foo"
+    }
   }
 }

--- a/json_test.go
+++ b/json_test.go
@@ -18,11 +18,32 @@ var _ = Describe("JsonConfig", func() {
 	})
 
 	Context("When the JSON config marshals properly", func() {
-		It("Should have the variables in config", func() {
+		It("Should have a string variable in config", func() {
 			Expect(cfg.Get("test")).To(Equal("123"))
+		})
+		It("Should have an int variable in config", func() {
+			Expect(cfg.Get("test_number")).To(Equal("1"))
+		})
+		It("Should have a bool variable in config", func() {
+			Expect(cfg.Get("test_bool")).To(Equal("true"))
+		})
+		It("Should have a float variable in config", func() {
+			Expect(cfg.Get("test_float")).To(Equal("12.34"))
 		})
 		It("Should not error", func() {
 			Expect(err).NotTo(HaveOccurred())
+		})
+		It("Should have the string value from a nested map", func() {
+			Expect(cfg.Get("test_object:nested_string")).To(Equal("abcd"))
+		})
+		It("Should have the string value from a deeply nested map", func() {
+			Expect(cfg.Get("double_nested:nested_object:test_inner")).To(Equal("foo"))
+		})
+		It("Should have the int value from a nested map", func() {
+			Expect(cfg.Get("test_object:nested_int")).To(Equal("987"))
+		})
+		It("Should have the values from an input array", func() {
+			Expect(cfg.Get("test_array")).To(Equal("1,2,3"))
 		})
 	})
 


### PR DESCRIPTION
The previous implementation of JsonConfig did not support nested structures. It also did not handle numeric types properly (i.e. a JSON value of 123 would become "123.000000"). This adds recursive parsing of the full structure so that the behavior is consistent with nconf:
- Nested structures are available by a ":" delimited key path
- Arrays are concatenated into commas separated values
- Int values are also properly formatted

Tests are included.
