### PR TITLE
Made changes for environment config parser

### DIFF
--- a/argv_test.go
+++ b/argv_test.go
@@ -14,6 +14,7 @@ var _ = Describe("ArgvConfig", func() {
 	BeforeEach(func() {
 		cfg = NewArgvConfig("test")
 		err = cfg.Load()
+		Expect(err == nil)
 	})
 	It("Should load variables from commandline", func() {
 		Expect(len(cfg.All()) >= 0).To(BeTrue())

--- a/env.go
+++ b/env.go
@@ -26,8 +26,8 @@ func NewEnvConfig(prefix string) ReadableConfig {
 func (self *EnvConfig) Load() (err error) {
 	env := os.Environ()
 	for _, pair := range env {
-		kv := strings.Split(pair, "=")
-		if kv != nil && len(kv) >= 2 {
+		kv := strings.SplitN(pair, "=", 2)
+		if kv != nil && len(kv) == 2 {
 			self.Set(strings.Replace(kv[0], self.Prefix, "", 1), kv[1])
 		}
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -15,6 +15,7 @@ var _ = Describe("EnvConfig", func() {
 	BeforeEach(func() {
 		cfg = NewEnvConfig("")
 		err = cfg.Load()
+		Expect(err == nil)
 	})
 	It("Should load variables from environment", func() {
 		Expect(len(cfg.All()) > 0).To(BeTrue())

--- a/env_test.go
+++ b/env_test.go
@@ -1,7 +1,6 @@
-package gonfig_test
+package gonfig
 
 import (
-	. "github.com/Nomon/gonfig"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"os"
@@ -22,8 +21,8 @@ var _ = Describe("EnvConfig", func() {
 		env := os.Environ()
 		Expect(len(env) > 0).To(BeTrue())
 		for _, kvpair := range env {
-			pairs := strings.Split(kvpair, "=")
-			Expect(len(pairs) >= 2).To(BeTrue())
+			pairs := strings.SplitN(kvpair, "=", 2)
+			Expect(len(pairs) == 2).To(BeTrue())
 			Expect(cfg.Get(pairs[0])).To(Equal(pairs[1]))
 		}
 	})


### PR DESCRIPTION
Which does NOT cut off parts after the second and all over entries of EQUAL (=) rune. 